### PR TITLE
Upgrade de openpyxl pour corriger le message d'erreur : Pandas requir…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ simplejson>=3.17.2
 watchdog>=2.0.2
 wincertstore>=0.2
 zipp>=3.4.0
-openpyxl==3.0.10
+openpyxl==3.1.5
 geopy~=2.1.0
 shapely>=1.7.1
 fastkml~=0.11


### PR DESCRIPTION
…es version '3.1.0' or newer of 'openpyxl' (version '3.0.10' currently installed)